### PR TITLE
Multi-port SPI library patch

### DIFF
--- a/hardware/arduino/xmega/libraries/SPI/SPI.cpp
+++ b/hardware/arduino/xmega/libraries/SPI/SPI.cpp
@@ -28,7 +28,6 @@ SPIClass::SPIClass(const SPISettings & init) : spi_settings(init)
 }
 
 void SPIClass::begin() {
-
   // Set SS to high so a connected chip will be "deselected" by default
   digitalWrite(spi_settings.ss, HIGH);
 

--- a/hardware/arduino/xmega/libraries/SPI/SPI.cpp
+++ b/hardware/arduino/xmega/libraries/SPI/SPI.cpp
@@ -13,21 +13,35 @@
 
 SPIClass SPI;
 
+/* 
+ * Constructor and other mods by Pat Deegan (http://flyingcarsandstuff.com/),
+ * November 2014, to allow for multiple SPI ports and remove hard-coded values
+ * for MISO/MOSI/SCK etc.  
+ * See SPI.h for details and usage.
+ */
+SPIClass::SPIClass() : spi_settings()
+{
+}
+
+SPIClass::SPIClass(const SPISettings & init) : spi_settings(init)
+{
+}
+
 void SPIClass::begin() {
 
   // Set SS to high so a connected chip will be "deselected" by default
-  digitalWrite(SS, HIGH);
+  digitalWrite(spi_settings.ss, HIGH);
 
   // When the SS pin is set as OUTPUT, it can be used as
   // a general purpose output port (it doesn't influence
   // SPI operations).
-  pinMode(SS, OUTPUT);
+  pinMode(spi_settings.ss, OUTPUT);
 
   // Warning: if the SS pin ever becomes a LOW INPUT then SPI
   // automatically switches to Slave, so the data direction of
   // the SS pin MUST be kept as OUTPUT.
-  SPCR |= _BV(MSTR);
-  SPCR |= _BV(SPE);
+  SPI_INTERNAL_PCTRL |= _BV(MSTR);
+  SPI_INTERNAL_PCTRL |= _BV(SPE);
 
   // Set direction register for SCK and MOSI pin.
   // MISO pin automatically overrides to INPUT.
@@ -35,36 +49,36 @@ void SPIClass::begin() {
   // clocking in a single bit since the lines go directly
   // from "input" to SPI control.  
   // http://code.google.com/p/arduino/issues/detail?id=888
-  pinMode(SCK, OUTPUT);
-  pinMode(MOSI, OUTPUT);
+  pinMode(spi_settings.clk, OUTPUT);
+  pinMode(spi_settings.mosi, OUTPUT);
 }
 
 
 void SPIClass::end() {
-  SPCR &= ~_BV(SPE);
+  SPI_INTERNAL_PCTRL &= ~_BV(SPE);
 }
 
 void SPIClass::setBitOrder(uint8_t bitOrder)
 {
   if(bitOrder == LSBFIRST) {
-    SPCR |= _BV(DORD);
+    SPI_INTERNAL_PCTRL |= _BV(DORD);
   } else {
-    SPCR &= ~(_BV(DORD));
+    SPI_INTERNAL_PCTRL &= ~(_BV(DORD));
   }
 }
 
 void SPIClass::setDataMode(uint8_t mode)
 {
-  SPCR = (SPCR & ~SPI_MODE_MASK) | mode;
+  SPI_INTERNAL_PCTRL = (SPI_INTERNAL_PCTRL & ~SPI_MODE_MASK) | mode;
 }
 
 void SPIClass::setClockDivider(uint8_t rate)
 {
 #if defined(__AVR_XMEGA__)
-  SPCR = (SPCR & ~(SPI_CLOCK_MASK | SPI_2XCLOCK_MASK)) | (rate & (SPI_CLOCK_MASK | SPI_2XCLOCK_MASK));
+  SPI_INTERNAL_PCTRL = (SPI_INTERNAL_PCTRL & ~(SPI_CLOCK_MASK | SPI_2XCLOCK_MASK)) | (rate & (SPI_CLOCK_MASK | SPI_2XCLOCK_MASK));
 #else
-  SPCR = (SPCR & ~SPI_CLOCK_MASK) | (rate & SPI_CLOCK_MASK);
-  SPSR = (SPSR & ~SPI_2XCLOCK_MASK) | ((rate >> 2) & SPI_2XCLOCK_MASK);
+  SPI_INTERNAL_PCTRL = (SPI_INTERNAL_PCTRL & ~SPI_CLOCK_MASK) | (rate & SPI_CLOCK_MASK);
+  SPI_INTERNAL_PSTATUS = (SPI_INTERNAL_PSTATUS & ~SPI_2XCLOCK_MASK) | ((rate >> 2) & SPI_2XCLOCK_MASK);
 #endif
 }
 

--- a/hardware/arduino/xmega/libraries/SPI/SPI.h
+++ b/hardware/arduino/xmega/libraries/SPI/SPI.h
@@ -9,18 +9,54 @@
  *
  *
  *
- * Nov 2014: by Pat Deegan (http://flyingcarsandstuff.com/), to
+ * Nov 2014: Mods by Pat Deegan (http://flyingcarsandstuff.com/), to
  * enable support for multiple SPI ports.  The "SPI" global, and various
- * defines (SPCR, SPSR) are unaffected, but the SPIClass itself may be 
- * used to instantiate other instances to interact through SPI with other
- * ports.  For example, on the Xmega128a3u, you could use:
- * 
- * SPI_DEFINE(SPI2, SPID, 11, 12, 13, 6); // instance name, port, SI, SO, SCK, SS
+ * defines (SPCR, SPSR) are still available, but the SPIClass itself may now be 
+ * used in two ways:
  *
- * Which would create an SPIClass object named SPI2... then,
- * SPI2.begin();
- * SPI2.transfer(0xFF); 
- * ... etc. 
+ * 
+ * 1) Dynamic switching/3rd party libraries
+ *   You can switch dynamically between ports using the SPI global.  This allows
+ *   using legacy code with a different port... for instance, to override some library's
+ *   use of the standard SPIC without needing to change anything in the 3rd party code,
+ *   start by defining settings for, say, SPID:
+ * 
+ *     // Create an SPISettings object (need not be global/persistent):
+ *     SPISettings myPortD(&SPID, SS1, MOSI1, MISO1, SCK1); // port*, cs, mosi, miso, sck
+ *
+ *     // tell the SPI global to switch its settings:
+ *     SPI.setConfiguration(myPortD);
+ *
+ *     // begin and operate as normal
+ *     SPI.begin();
+ *     SPI.transfer(0x42); // ... etc. 
+ * 
+ *   The configuration() may be used at any time, just remember to call begin() once
+ *   for each port you'll be using.
+ *   
+ *   In this case, the SPCR/SPDR/SPSR "registers" will point to whatever the _current_
+ *   setting is.
+ * 
+ *
+ * 2) Additional instances
+ *   You may instantiate other instances to interact through SPI with other
+ *   ports.  For example, on the Xmega128a3u, you could use:
+ * 
+ *     // instance name, port, ss, mosi, miso, sck
+ *     SPI_DECLARE(SPI2, SPID, SS1, MOSI1, MISO1, SCK1);
+ *
+ *   Which would create an SPIClass object named SPI2... then,
+ *     SPI2.begin();
+ *     SPI2.transfer(0xFF); 
+ *     // ... etc. 
+ * 
+ *   In most instances, the SPI_DEFINE() should be done globally so you'll have access to 
+ *   to it everywhere.  You may add:
+ *     SPI_EXTERNAL_DECL(SPI2);
+ *   in a header file to make it visible to any code that includes the header.
+ *
+ *   In this case, the SPCR/SPDR/SPSR "registers" will point to the _original_ SPI (0) 
+ *   global, so be weary when using 3rd party libs.
  */
 
 #ifndef _SPI_H_INCLUDED
@@ -30,13 +66,16 @@
 #include <Arduino.h>
 #include <avr/pgmspace.h>
 
+
 #if defined(__AVR_XMEGA__)
   #if !defined(SPI_PORT)
     #error "Please define SPI_PORT in pins_arduino for your board"
   #endif
-  #define SPCR	SPI_PORT.CTRL
-  #define SPSR	SPI_PORT.STATUS
-  #define SPDR	SPI_PORT.DATA
+
+
+  #define SPCR	((SPI.configuration()->port)->CTRL)
+  #define SPSR	((SPI.configuration()->port)->STATUS)
+  #define SPDR	((SPI.configuration()->port)->DATA)
   #define SPE	SPI_ENABLE_bp
   #define MSTR	SPI_MASTER_bp
   #define SPI_INT_FLAG	SPI_IF_bp
@@ -63,7 +102,7 @@
 
 #else
 #define SPI_INT_EN		SPIE
-#define SPI_INT_FLAG	SPIF
+#define SPI_INT_FLAG		SPIF
 
 #define SPI_CLOCK_DIV4 0x00
 #define SPI_CLOCK_DIV16 0x01
@@ -86,30 +125,38 @@
 
 
 
+
+
+
 #if defined(__AVR_XMEGA__)
+
   #define SPI_INTERNAL_PCTRL	((spi_settings.port)->CTRL)
   #define SPI_INTERNAL_PSTATUS	((spi_settings.port)->STATUS)
   #define SPI_INTERNAL_PDATA	((spi_settings.port)->DATA)
   #define SPI_INTERNAL_INTCTRL  ((spi_settings.port)->INTCTRL)
-  #define SPI_DEFINE(name, port, SI, SO, CL, CS) SPIClass name(SPISettings(&(port), SI, SO, CL, CS))
+  #define SPI_DEFINE(name, port, cs, si, so, clk) SPIClass name(SPIconfiguration(&(port), cs, si, so, clk))
 
 #else
   #define SPI_INTERNAL_PCTRL	SPCR
   #define SPI_INTERNAL_PSTATUS	SPSR
   #define SPI_INTERNAL_PDATA	SPDR
 
-  #define SPI_DEFINE(name, SI, SO, CL, CS) SPIClass name(SPISettings(SI, SO, CL, CS))
+  #define SPI_DEFINE(name, cs, si, so, clk) SPIClass name(SPIconfiguration(cs, si, so, clk))
 #endif
+
+
+#define SPI_EXTERNAL_DECL(name)		extern SPIClass name;
+
 
 typedef struct SPISettingsStruct {
 
 #if defined(__AVR_XMEGA__)
 	SPI_t * port;
 #endif
+	uint8_t ss;
 	uint8_t mosi;
 	uint8_t miso;
 	uint8_t clk;
-	uint8_t ss;
 
 
 
@@ -117,10 +164,10 @@ typedef struct SPISettingsStruct {
 #if defined(__AVR_XMEGA__)
 		port(&(SPI_PORT)),
 #endif
+		ss(SS),
 		mosi(MOSI),
 		miso(MISO),
-		clk(SCK),
-		ss(SS)
+		clk(SCK)
 	{
 	}
 
@@ -128,14 +175,14 @@ typedef struct SPISettingsStruct {
 #if defined(__AVR_XMEGA__)
 		SPI_t * port, 
 #endif
-		uint8_t slave_input, uint8_t slave_output, uint8_t clock, uint8_t select) :
+		uint8_t select, uint8_t slave_input, uint8_t slave_output, uint8_t clock) :
 #if defined(__AVR_XMEGA__)
 		port(port),
 #endif
+		ss(select),
 		mosi(slave_input),
 		miso(slave_output),
-		clk(clock),
-		ss(select)
+		clk(clock)
 	{
 	}
 } SPISettings;
@@ -162,19 +209,24 @@ public:
 
   SPIClass();
   SPIClass(const SPISettings & init);
+  inline const SPISettings * configuration() { return  &spi_settings;}
+  inline void setConfiguration(const SPISettings & settings) { spi_settings = settings;}
 private:
   SPISettings spi_settings;
 
 
 };
 
+
 extern SPIClass SPI;
 
 byte SPIClass::transfer(byte _data) {
-  SPDR = _data;
-  while (!(SPSR & _BV(SPI_INT_FLAG)))
+
+  SPI_INTERNAL_PDATA = _data;
+  while (!(SPI_INTERNAL_PSTATUS & _BV(SPI_INT_FLAG)))
     ;
-  return SPDR;
+  return SPI_INTERNAL_PDATA;
+
 }
 
 void SPIClass::attachInterrupt() {


### PR DESCRIPTION
These changes to the standard SPI lib leave existing functionality as-is but allow for expanded use of SPI on platforms that have multiple ports available.  The SPI.h header includes full documentation, but in essence there are two new ways to use SPI for xmega:

1) Dynamically adjusting the SPI global instance to use another port.  This is the best option for use with 3rd party code--I've tested, for example, using the Dataflash library on SPID by simply:

  // creating a config
  SPISettings myPortD(&SPID, SS1, MOSI1, MISO1, SCK1);
  // assigning it to the global SPI
  SPI.setConfiguration(myPortD);

prior to the SPI.begin() call.  Without modifications, the Dataflash library code (which used SPI.methods() as well as SPSR/SPCR) just worked.

You can "hot swap" between ports, by calling setConfiguration() at any time (as long as begin() was called once per config/port).

2) Using additional instances.  When using SPI directly, you can instantiate another SPIClass object and use that, e.g.

  // create an "SPI2" for the D port SPI
  SPI_DECLARE(SPI2, SPID, SS1, MOSI1, MISO1, SCK1);

  // use SPIClass API:
  SPI2.begin();
  SPI2.transfer(0xFF); 

I'd appreciate feedback and eventual inclusion in the main trunk. 

Regards,
Pat Deegan
http://flyingcarsandstuff.com/
