### PR TITLE
Timeout option for Wire library.

### DIFF
--- a/hardware/arduino/avr/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/avr/libraries/Wire/Wire.cpp
@@ -82,7 +82,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop
     quantity = BUFFER_LENGTH;
   }
   // perform blocking read into buffer
-  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
+  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop, auto_timeout);
   // set rx buffer iterator vars
   rxBufferIndex = 0;
   rxBufferLength = read;

--- a/hardware/arduino/avr/libraries/Wire/Wire.h
+++ b/hardware/arduino/avr/libraries/Wire/Wire.h
@@ -25,6 +25,8 @@
 #include <inttypes.h>
 #include "Stream.h"
 
+typedef uint8_t AutoTimeoutMs;
+
 #define BUFFER_LENGTH 32
 
 class TwoWire : public Stream
@@ -44,6 +46,8 @@ class TwoWire : public Stream
     static void (*user_onReceive)(int);
     static void onRequestService(void);
     static void onReceiveService(uint8_t*, int);
+
+    AutoTimeoutMs auto_timeout;
   public:
     TwoWire();
     void begin();
@@ -70,6 +74,13 @@ class TwoWire : public Stream
     inline size_t write(long n) { return write((uint8_t)n); }
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
+
+
+    inline AutoTimeoutMs autoTimeout() { return auto_timeout;}
+    inline void setAutoTimeout(AutoTimeoutMs ms) { auto_timeout = ms;}
+
+
+
     using Print::write;
 };
 

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.c
@@ -112,19 +112,29 @@ void twi_setAddress(uint8_t address)
  *          sendStop: Boolean indicating whether to send a stop at the end
  * Output   number of bytes read
  */
-uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop)
+uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop, uint8_t timeoutMs)
 {
   uint8_t i;
+  uint32_t timeoutTime = 0;
 
   // ensure data will fit into buffer
   if(TWI_BUFFER_LENGTH < length){
     return 0;
   }
 
+  if (timeoutMs)
+  {
+     timeoutTime = millis() + timeoutMs;
+  }
   // wait until twi is ready, become master receiver
   while(TWI_READY != twi_state){
+ 
+    if (timeoutTime && millis() > timeoutTime)
+	return 0;
+
     continue;
   }
+
   twi_state = TWI_MRX;
   twi_sendStop = sendStop;
   // reset error state (0xFF.. no error occured)

--- a/hardware/arduino/avr/libraries/Wire/utility/twi.h
+++ b/hardware/arduino/avr/libraries/Wire/utility/twi.h
@@ -40,7 +40,7 @@
   
   void twi_init(void);
   void twi_setAddress(uint8_t);
-  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
+  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t timeoutMs=0);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
   void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );

--- a/hardware/arduino/xmega/cores/xmega/wiring_rtc.c
+++ b/hardware/arduino/xmega/cores/xmega/wiring_rtc.c
@@ -1,0 +1,222 @@
+#include "wiring_rtc.h"
+
+
+
+#if defined(USE_RTC)
+/* we want the on-board RTC */
+
+#ifndef RTC32
+/* and this ISN'T and RTC32 implementation */
+
+
+
+
+#define RTC_MAX_PERIOD_TICKS	0xffff
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+RTCPeriodicCallback rtc_periodic_callback = NULL;
+void wiring_rtc_shift_count_to_rtc_millis(void);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+
+
+#define RTC_TURN_OFF()	RTC.CTRL = ( RTC.CTRL & ~RTC_PRESCALER_gm ) | RTC_PRESCALER_OFF_gc
+#define RTC_TURN_ON()	RTC.CTRL = ( RTC.CTRL & ~RTC_PRESCALER_gm ) | RTC_PRESCALER_DIV1_gc;
+
+
+void wiring_setup_rtc_clocksource(void)
+{
+	/* Turn on internal 32kHz. */
+	OSC.CTRL |= OSC_RC32KEN_bm;
+
+	do {
+		/* Wait for the 32kHz oscillator to stabilize. */
+	} while ( ( OSC.STATUS & OSC_RC32KRDY_bm ) == 0);
+		
+
+	/* Set internal 32kHz oscillator as clock source for RTC. */
+	CLK.RTCCTRL = CLK_RTCSRC_RCOSC_gc | CLK_RTCEN_bm;/* 1kHz */
+}
+
+
+void wiring_setup_rtc(void)
+{
+	RTC_WAIT_UNTIL_READY();
+
+	/* Configure RTC period to "infinity" -- we'll only take cpu time when either:
+
+		* a request is made to know the millis/micros
+		* we need to inform the periodic callback that time has passed, or
+		* we overflow, and run out of space in our 16bit counter. 
+	*/
+	RTC.PER = RTC_MAX_PERIOD_TICKS; /* longest period possible */
+	RTC.CNT = 0;
+	RTC.COMP = 0;
+	RTC_TURN_ON();
+
+	/* Enable overflow interrupt, start with compare interrupt disabled */	
+	RTC.INTCTRL = ( RTC.INTCTRL & ~( RTC_COMPINTLVL_gm | RTC_OVFINTLVL_gm ) ) |
+	              RTC_OVFINTLVL_LO_gc |
+	              RTC_COMPINTLVL_OFF_gc;
+}
+
+
+/*! \brief Set a callback to be triggered every N seconds.
+ *
+ * Set (or clear, if passing null) a callback to be triggered every X seconds.
+ * this is most useful if you want to keep an NVRAM cache of the last known time,
+ * to mitigate power failures, etc.
+ */
+void wiring_rtc_set_periodic_callback(RTCPeriodicCallback cb, uint16_t every_seconds)
+{
+
+	RTC_WAIT_UNTIL_READY();
+ 	uint8_t oldSREG = SREG;
+	/* disable interrupts */
+	cli();
+	if (cb && every_seconds)
+	{
+		wiring_rtc_shift_count_to_rtc_millis();
+		/* set our compare to trigger when interval expires */
+		RTC.COMP = (1000UL * every_seconds);
+		RTC.INTCTRL = ( RTC.INTCTRL & ~RTC_COMPINTLVL_gm) | RTC_COMPINTLVL_LO_gc;
+	} else {
+		RTC.COMP = 0;
+		/* clear the compare interrupt */
+		RTC.INTCTRL = ( RTC.INTCTRL & ~RTC_COMPINTLVL_gm) | RTC_COMPINTLVL_OFF_gc;
+		
+	}
+
+	rtc_periodic_callback = cb;
+	
+	SREG = oldSREG;
+}
+
+
+/*
+ * Zero the clock.
+ */
+void wiring_rtc_zero_clock(void)
+{
+	
+ 	uint8_t oldSREG = SREG;
+	/* disable interrupts */
+	cli();
+	rtc_millis = 0;
+	SREG = oldSREG;
+}
+
+
+
+
+/*! \brief returns current RTC milliseconds count.
+ *
+ * The ms counter has 0-cost while running in the background,
+ * and will update it's idea of the time based on the RTC 
+ * counter when millis() is actually called (and in a few other
+ * circumstances, namely on overflow and when a periodic callback 
+ * has been requested).
+*/
+unsigned long millis()
+{
+ 	uint32_t m, tmp;
+
+
+	RTC_WAIT_UNTIL_READY();
+
+ 	uint8_t oldSREG = SREG;
+	/* disable interrupts */
+	cli();
+
+	tmp = RTC.CNT;
+	if (rtc_periodic_callback || tmp < 0x4000)
+	{
+		// still small (or have callback and assume user is taking care of things), so just return the sum value
+		m = rtc_millis + tmp;
+	} else {
+		// been a long time, reset the counter to avoid overflow
+		wiring_rtc_shift_count_to_rtc_millis();
+		m = rtc_millis;
+	} 
+
+	
+	SREG = oldSREG;
+	return m;
+}
+
+
+unsigned long micros(void) {
+	/* TODO: Get real micros and not just millis*1000 */
+	unsigned long m = millis();
+        return m*1000;
+}
+
+
+
+/* wiring_rtc_shift_count_to_rtc_millis
+ * augments the rtc_millis counter with whatever time has passed
+ * and resets the counter to 0.
+ */
+void wiring_rtc_shift_count_to_rtc_millis(void)
+{
+	// turn it off...
+	RTC_TURN_OFF();
+	RTC_WAIT_UNTIL_READY();
+
+
+ 	uint8_t oldSREG = SREG;
+	cli();	
+
+	rtc_millis += RTC.CNT;
+	RTC.CNT = 0;
+
+
+	SREG = oldSREG;
+
+	RTC_TURN_ON();
+}
+
+
+
+
+
+/*! \brief RTC overflow interrupt service routine.
+ *
+ *  This ISR keeps track of RTC counter overflows, so
+ *  we don't just lose 16bits-worth of millis.
+ */
+ISR(RTC_OVF_vect)
+{
+	rtc_millis += (RTC_MAX_PERIOD_TICKS);
+
+}
+
+/*! \brief RTC compare interrupt service routine.
+ * 
+ * This ISR is only triggered when the use has requested
+ * a periodic callback.  Time is updated prior to triggering.
+*/
+ISR(RTC_COMP_vect)
+{
+
+	if (rtc_periodic_callback)
+	{
+		wiring_rtc_shift_count_to_rtc_millis();
+		rtc_periodic_callback();
+	}
+
+}
+
+
+
+#endif /* NOT RTC32 */
+#endif /* USE_RTC */
+
+

--- a/hardware/arduino/xmega/cores/xmega/wiring_rtc.h
+++ b/hardware/arduino/xmega/cores/xmega/wiring_rtc.h
@@ -1,0 +1,77 @@
+#ifndef WIRING_RTC_IMPL_H_
+#define WIRING_RTC_IMPL_H_
+
+/*
+ *
+ * RTC real-time clock mods
+ *  Copyright (c) 2014 Pat Deegan, flyingcarsandstuff.com
+ *
+ * This is simply the USE_RTC stuff from wiring.c, isolated
+ * from the main code in order to simplify variations on the
+ * implementation (e.g. the RTC32 available on some xmega).
+ * 
+ * It is only slightly modified and retains it's original 
+ * license, as
+ *
+ *
+ *
+ * Copyright (c) 2005-2006 David A. Mellis
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA  02111-1307  USA
+ *
+ *
+*/
+
+#include "wiring_private.h"
+
+#if defined(USE_RTC)
+/* we want the on-board RTC */
+
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+
+typedef void(*RTCPeriodicCallback)(void);
+void wiring_setup_rtc_clocksource(void);
+void wiring_setup_rtc(void);
+
+
+extern volatile unsigned long seconds_count ;
+
+#ifndef RTC32
+extern volatile unsigned long rtc_millis;
+
+void wiring_rtc_set_periodic_callback(RTCPeriodicCallback cb, uint16_t every_seconds);
+void wiring_rtc_zero_clock(void);
+
+
+#define RTC_IS_BUSY() 			(RTC.STATUS & RTC_SYNCBUSY_bm)
+#define RTC_WAIT_UNTIL_READY()		while(RTC_IS_BUSY()) 
+
+#endif /* NOT RTC32 */
+
+
+#ifdef __cplusplus
+} /* extern C */
+#endif
+
+
+#endif /* USE_RTC */
+#endif /* WIRING_RTC_IMPL_H_ */
+
+

--- a/hardware/arduino/xmega/cores/xmega/wiring_rtc32.c
+++ b/hardware/arduino/xmega/cores/xmega/wiring_rtc32.c
@@ -1,0 +1,319 @@
+#include "wiring_rtc32.h"
+
+/*
+ *
+ * RTC32 real-time clock implementation for Arduino/Xmegaduino.
+ *  Copyright (c) 2014 Pat Deegan, flyingcarsandstuff.com
+ *
+ *
+ * This program library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *
+ * This code leverages the RTC32, battery-backed, real-time clock
+ * to keep track of (you guessed it) time.
+ *
+ * It keeps interrupt activity down to a minimum, only accessing the
+ * RTC when required to, and is smart enough to do setup on first time
+ * power-up while leaving things running smoothly when power returns
+ * after an interruption (assuming you have a functional battery tied
+ * to VBAT).
+ *
+ * For this all to work, you must have a battery *and* you must configure
+ * brown-out detection.  In essence, you need to set the BODACT to Enabled,
+ * BODPD (powerdown) to enabled or sampled (to save power) and the BODLEVEL
+ * to something sensible.  Here are the settings used while testing on an 
+ * xmega256A3BU:
+ *
+ *   FUSE2:	0xFD 	(sampled powerdown BOD)
+ *   FUSE5:	0xEB	(BODACT enabled, BODLEVEL 011/2.6V)
+ *
+ *
+*/
+
+
+#if defined(USE_RTC)
+
+/* we want the on-board RTC */
+
+#ifdef RTC32
+/* Yes, this is 32-bit RTC */
+
+extern volatile unsigned long seconds_count;
+
+RTCPeriodicCallback rtc32_periodic_callback = NULL;
+
+
+
+uint8_t wiring_rtc32_needed_reset(void)
+{
+
+
+	uint8_t backupBatStatus = VBAT.STATUS;
+	uint8_t needToReset = 1;
+	uint8_t potentialIssues = (VBAT_BBPWR_bm | VBAT_BBPORF_bm | VBAT_BBBORF_bm );
+	if (!(backupBatStatus & potentialIssues)) {
+		// we *aren't without battery power, no BBPOR probs, no backup brown-out
+		VBAT.CTRL = VBAT_ACCEN_bm;
+		if (! (backupBatStatus & VBAT_XOSCFAIL_bm))
+		{
+			// no osc failure...
+			// looks pretty good, lets NOT reset
+			needToReset = 0;
+		}
+	}
+
+	return needToReset;
+
+}
+
+
+/* and we are indeed on a platform with 32-bit RTC built-in. */
+void wiring_setup_rtc_clocksource(void)
+{
+	if (! wiring_rtc32_needed_reset())
+		return;
+
+	// Disable RTC and wait until ready, make certain it's off...
+	RTC32.CTRL = 0;
+	RTC32_WAIT_UNTIL_READY();
+
+	// enable RTC (i.e. disable power reduction for it)	
+	PR.PRGEN &= ~PR_RTC_bm;
+
+
+
+	// VBAT access
+	VBAT.CTRL |= VBAT_ACCEN_bm;
+
+	// reset backup registers
+	VBAT.BACKUP1 = 0;
+	VBAT.BACKUP0 = 0;
+
+        CCP = CCP_IOREG_gc; // Secret handshake 
+	VBAT.CTRL = VBAT_RESET_bm;
+
+	VBAT.CTRL |= VBAT_XOSCFDEN_bm;
+	// Let the backup system stabilize
+	delayMicroseconds(220);
+	VBAT.CTRL |= VBAT_XOSCEN_bm | VBAT_XOSCSEL_bm; // enable x osc, and select 1024Hz
+
+	while (!(VBAT.STATUS & VBAT_XOSCRDY_bm));
+
+
+}
+
+
+void wiring_rtc32_set_periodic_callback(RTCPeriodicCallback cb, uint16_t every_seconds)
+{
+
+	// Disable RTC and wait until ready, make certain it's off...
+	RTC32.CTRL = 0;
+	RTC32_WAIT_UNTIL_READY();
+
+	if (cb && every_seconds > 0 && every_seconds <= RTC32_PERIODICCALLBACK_MAX_INTERVAL_SECONDS)
+	{
+	
+		RTC32.COMP = (1024UL * every_seconds);
+
+		// make sure we catch overflows *and* compare INTs
+		RTC32.INTCTRL = RTC32_OVFINTLVL_LO_gc | RTC32_COMPINTLVL_LO_gc;
+		RTC32.INTFLAGS = RTC32_OVFIF_bm | RTC32_COMPIF_bm;
+	} else {
+
+		RTC32.INTCTRL = RTC32_OVFINTLVL_LO_gc | RTC32_COMPINTLVL_OFF_gc;
+		RTC32.INTFLAGS = RTC32_OVFIF_bm ;
+	}	
+
+	rtc32_periodic_callback = cb;
+
+	RTC32.CTRL = RTC32_ENABLE_bm;
+	// sync it
+	RTC32_WAIT_UNTIL_READY();
+}
+
+
+
+
+void wiring_setup_rtc(void)
+{
+
+	if (! wiring_rtc32_needed_reset())
+	{
+		// we don't need a reset, but we need to restore our seconds counter, as best we can...
+		seconds_count = ((VBAT.BACKUP1 * VBAT_BACKUP_INTERVAL_SECONDS) << 8);
+		seconds_count += (VBAT.BACKUP0 * VBAT_BACKUP_INTERVAL_SECONDS);
+
+		return;
+	}
+
+
+	RTC32.PER = 0xffffffff;
+
+	// setup max period,
+	// and start at 0, as we're resetting...
+	RTC32.CNT = 0;
+	
+	// RTC32.COMP = (1024UL * VBAT_BACKUP_INTERVAL_SECONDS);
+
+	// sync it before proceeding
+	RTC32_WAIT_UNTIL_READY();
+
+	// make sure we catch overflows, and don't loose our seconds every 48 days or so
+	RTC32.INTCTRL = RTC32_OVFINTLVL_LO_gc | RTC32_COMPINTLVL_OFF_gc;
+	// RTC32.INTCTRL = RTC32_OVFINTLVL_LO_gc | RTC32_COMPINTLVL_LO_gc;
+
+
+	RTC32.INTFLAGS = RTC32_OVFIF_bm ;
+	// RTC32.INTFLAGS = RTC32_OVFIF_bm | RTC32_COMPIF_bm;
+
+	RTC32.CTRL = RTC32_ENABLE_bm;
+
+	// sync it
+	RTC32_WAIT_UNTIL_READY();
+
+}
+
+void wiring_rtc32_zero_clock(void)
+{
+	// Disable RTC and wait until ready, make certain it's off...
+	RTC32.CTRL = 0;
+	RTC32_WAIT_UNTIL_READY();
+	
+	seconds_count = 0;
+	RTC32.CNT = 0;
+	// sync it before proceeding
+	RTC32_WAIT_UNTIL_READY();
+
+	RTC32.CTRL = RTC32_ENABLE_bm;
+	// sync it
+	RTC32_WAIT_UNTIL_READY();
+
+
+}
+
+
+
+/*
+ * millis()
+ * rather than interrupt every time we get a ~1kHz tick, we get the actual
+ * value in the RTC counter when asked for it, adding greater expense to the 
+ * op when it's used but basically costing nothing the rest of the time.
+ *
+ * NOTE: the value is "real" in that we don't simply rely on 1 tick being ~equal
+ * to 1ms (because it isn't, viz the 1024Hz clock).  Instead, we do a little
+ * math, basically taking the RTC count * 1000/1024.  This introduces an 
+ * issue: anything beyond 0x20000000 (i.e. about 68 minutes) will result in 
+ * an overflow (if we use 32bit ints, similar issues using floats).  So: 
+ * when the millis() function is called, if it's been more than 32 seconds
+ * since the last time, we add the full seconds into seconds_count and only
+ * keep the remainder in our RTC counter.
+ *
+ * This all works nicely, as long as you stick to the Arduino SDK functions.
+ * If you want to play directly with the RTC32 stuff, you'll have to account
+ * for this, perhaps using 
+ *   extern volatile unsigned long seconds_count;
+ * directly, or avoiding the millis()/micros() calls, or fix this here somehow.
+ */
+
+#define SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT	10
+unsigned long millis()
+{
+ 	unsigned long count, tmp;
+ 	
+ 
+	// disable interrupts while we read ?
+#ifdef RTC32_DISABLE_INTERRUPTS_WHILE_READING_CNT
+ 	uint8_t oldSREG = SREG;
+	cli();
+#endif
+
+	RTC32_FETCH_COUNTER(count);
+
+
+#ifdef RTC32_DISABLE_INTERRUPTS_WHILE_READING_CNT
+	SREG = oldSREG;
+#endif
+
+	if ((!rtc32_periodic_callback) && (count > (1<<SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT)))
+	{
+		// we don't want to overflow, so we count seconds and clear
+		tmp = (count>>SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT); // number of whole seconds
+
+		count -= (tmp<<SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT); // keep remainder
+		seconds_count += tmp;
+
+		RTC32_SET_COUNTER(count);
+
+		/*
+		if (seconds_count % VBAT_BACKUP_INTERVAL_SECONDS == 0)
+			BACKUP_SECONDS_COUNT(seconds_count);
+		*/
+
+
+		
+	}
+	// actual is corrected to account for 1024Hz clock
+	// so we multiply by 1000 and then divide by 1024 (right shifting)
+	tmp = (seconds_count * 1000UL) + ((count * 1000UL) >> 10);
+
+	return tmp;
+
+}
+
+unsigned long micros(void) {
+	// TODO: Get real micros and not just millis*1000
+
+	return millis() * 1000UL;
+
+	/* slightly more precise version, but doesn't handle our 
+	   overflow situation (described above millis()) so fuggedaboutit...
+
+	unsigned long pseudomillis;
+	RTC32_FETCH_COUNTER(pseudomillis);
+	return (seconds_count * 1000000UL) + (pseudomillis * 977UL); // approximation based on 1024Hz counter
+	*/
+
+}
+
+
+ISR(RTC32_COMP_vect)
+{
+	
+ 	unsigned long count, secs_elapsed;
+ 	// do we need cli()?
+
+	RTC32_FETCH_COUNTER(count);
+	secs_elapsed = count>>SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT;
+	seconds_count += secs_elapsed;
+	count -= (secs_elapsed<<SECONDS_COUNTER_BLOCK_SIZE_BITSHIFT);
+	RTC32_SET_COUNTER(count);
+
+
+	if (rtc32_periodic_callback)
+		rtc32_periodic_callback();
+
+	// BACKUP_SECONDS_COUNT(seconds_count);
+
+
+
+
+}
+
+ISR(RTC32_OVF_vect)
+{
+	// wow, we've been doing nothing for a long time...
+	seconds_count += 0x400000UL; // 0xffffffff clocks @ 0x2000 Hz, so about 48.5 days.
+}
+
+
+#endif /* RTC32 */
+#endif /* USE_RTC */
+

--- a/hardware/arduino/xmega/cores/xmega/wiring_rtc32.h
+++ b/hardware/arduino/xmega/cores/xmega/wiring_rtc32.h
@@ -1,0 +1,112 @@
+#ifndef WIRING_RTC32_IMPL_H_
+#define WIRING_RTC32_IMPL_H_
+
+#include "wiring_private.h"
+
+/*
+ *
+ * RTC32 real-time clock implementation for Arduino/Xmegaduino.
+ *  Copyright (c) 2014 Pat Deegan, flyingcarsandstuff.com
+ *
+ *
+ * This program library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ *
+ * This code leverages the RTC32, battery-backed, real-time clock
+ * to keep track of (you guessed it) time.
+ *
+ * It keeps interrupt activity down to a minimum, only accessing the
+ * RTC when required to, and is smart enough to do setup on first time
+ * power-up while leaving things running smoothly when power returns
+ * after an interruption (assuming you have a functional battery tied
+ * to VBAT).
+ *
+ * For this all to work, you must have a battery *and* you must configure
+ * brown-out detection.  In essence, you need to set the BODACT to Enabled,
+ * BODPD (powerdown) to enabled or sampled (to save power) and the BODLEVEL
+ * to something sensible.  Here are the settings used while testing on an 
+ * xmega256A3BU:
+ *
+ *   FUSE2:	0xFD 	(sampled powerdown BOD)
+ *   FUSE5:	0xEB	(BODACT enabled, BODLEVEL 011/2.6V)
+ *
+ *
+*/
+
+#if defined(USE_RTC)
+// we want the on-board RTC
+#ifdef RTC32
+
+#include "wiring_rtc.h"
+
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+#define RTC32_PERIODICCALLBACK_MAX_INTERVAL_SECONDS	(66*60)
+
+uint8_t wiring_rtc32_needed_reset(void);
+void wiring_rtc32_set_periodic_callback(RTCPeriodicCallback cb, uint16_t every_seconds);
+
+void wiring_rtc32_zero_clock(void);
+
+
+
+
+#ifdef __cplusplus
+} /* extern C */
+#endif
+
+
+
+#define VBAT_BACKUP_INTERVAL_SECONDS		2
+
+
+#define RTC32_IS_BUSY() 			(RTC32.SYNCCTRL & RTC32_SYNCBUSY_bm)
+#define RTC32_WAIT_UNTIL_READY()		while(RTC32_IS_BUSY()) 
+
+
+#define RTC32_SET_COUNTER(count) \
+	/* stahp! */ \
+	RTC32.CTRL = 0; \
+	RTC32_WAIT_UNTIL_READY(); \
+	RTC32.CNT = count; \
+	/* ok, continue */ \
+	RTC32.CTRL = RTC32_ENABLE_bm;
+
+
+#define RTC32_FETCH_COUNTER(intoVar)	\
+	RTC32.SYNCCTRL = RTC32_SYNCCNT_bm; \
+	RTC32_WAIT_UNTIL_READY(); \
+	intoVar = RTC32.CNT;
+
+
+#define BACKUP_SECONDS_COUNT(secs) \
+	{ \
+	VBAT.BACKUP1 = (0xff & (((secs)/VBAT_BACKUP_INTERVAL_SECONDS) >> 8)); \
+	VBAT.BACKUP0 = (((secs)/VBAT_BACKUP_INTERVAL_SECONDS) & 0xff); \
+	}
+
+
+
+#endif /* USE_RTC */
+#endif /* RTC32 */
+#endif /* WIRING_RTC32_IMPL_H_ */
+
+
+
+
+
+
+
+
+

--- a/hardware/arduino/xmega/libraries/RealTimeClock/LICENSE.txt
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/LICENSE.txt
@@ -1,0 +1,71 @@
+RealTimeClock xmega library
+Copyright (C) 2014 Pat Deegan, http://flyingcarsandstuff.com/
+Released under the LGPL and licensed as described here.
+
+
+                     GNU LESSER GENERAL PUBLIC LICENSE
+
+                           Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+0. Additional Definitions.
+
+As used herein, “this License” refers to version 3 of the GNU Lesser General Public License, and the “GNU GPL” refers to version 3 of the GNU General Public License.
+
+“The Library” refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An “Application” is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A “Combined Work” is a work produced by combining or linking an Application with the Library. The particular version of the Library with which the Combined Work was made is also called the “Linked Version”.
+
+The “Minimal Corresponding Source” for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The “Corresponding Application Code” for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+1. Exception to Section 3 of the GNU GPL.
+
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+2. Conveying Modified Versions.
+
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+    a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+    b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+
+The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+    a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+    b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+    a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+    b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+    c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+    d) Do one of the following:
+        0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+        1) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+    e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+    a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+    b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.
+

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTC16.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTC16.cpp
@@ -1,0 +1,104 @@
+/*
+ **  RTC16.cpp, part of the RealTimeClock library.
+ **  RTC (16bit) implementation of the RealTimeClock::Device.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This library is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ ** The library incorporates public domain code, namely the DateTime and
+ ** TimeSpan implementations by JeeLabs (http://news.jeelabs.org/code/),
+ ** and retain their original licensing.
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available
+ ** on certain chips, like the Atmel XMEGA.
+ **
+ ** Along with modifications to the Xmegaduino library's wiring
+ ** implementation, this will allow you to easily deal with an
+ ** RTC-based time system.  Use this library to get and set the
+ ** real datetime, and use millis()/micros() as usual.
+ **
+ **
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ **
+ ** 	2) You are using a variant that actually enables the RTC
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ **
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ **
+ **
+ **
+ ** Pat Deegan http://flyingcarsandstuff.com
+ */
+
+
+#include "includes/RTCDevice.h"
+
+#ifdef USE_RTC
+#ifndef RTC32
+
+#include "wiring_rtc.h"
+
+
+namespace RealTimeClock {
+
+uint32_t Device::offset = 0;
+
+
+DateTime Device::rebaseCounter()
+{
+
+	DateTime nowTime = now();
+	adjust(nowTime, true);
+	return nowTime;
+}
+void Device::adjust(const DateTime& dt, bool resetRTCCounter)
+{
+	if (resetRTCCounter)
+	{
+		wiring_rtc_zero_clock();
+	}
+
+	offset = dt.unixtime() - (millis() / 1000);
+
+}
+void Device::setPeriodicCallback(PeriodicCallback cb, uint16_t every_seconds)
+{
+	wiring_rtc_set_periodic_callback(cb, every_seconds);
+
+}
+
+
+void Device::clearPeriodicCallback()
+{
+
+	wiring_rtc_set_periodic_callback(NULL, 0);
+}
+
+
+
+
+} /* namespace RealTimeClock */
+
+
+#endif /* NOT RTC32 */
+#endif /* using RTC */
+
+

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTC16.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTC16.cpp
@@ -62,6 +62,13 @@ namespace RealTimeClock {
 uint32_t Device::offset = 0;
 
 
+bool Device::wasResetAtPowerup()
+{
+	 return true; // always true, no battery backup...
+
+}
+
+
 DateTime Device::rebaseCounter()
 {
 

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTC32.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTC32.cpp
@@ -60,7 +60,11 @@ namespace RealTimeClock {
 
 uint32_t Device::offset = 0;
 
+bool Device::wasResetAtPowerup()
+{
+	 return wiring_rtc32_needed_reset();
 
+}
 DateTime Device::rebaseCounter()
 {
 	DateTime nowTime = now();

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTC32.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTC32.cpp
@@ -1,0 +1,100 @@
+/*
+ **  RTC32.cpp, part of the RealTimeClock library.
+ **  RTC32 implementation of the RealTimeClock::Device.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This library is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ ** The library incorporates public domain code, namely the DateTime and
+ ** TimeSpan implementations by JeeLabs (http://news.jeelabs.org/code/),
+ ** and retain their original licensing.
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available
+ ** on certain chips, like the Atmel XMEGA.
+ **
+ ** Along with modifications to the Xmegaduino library's wiring
+ ** implementation, this will allow you to easily deal with an
+ ** RTC-based time system.  Use this library to get and set the
+ ** real datetime, and use millis()/micros() as usual.
+ **
+ **
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ **
+ ** 	2) You are using a variant that actually enables the RTC
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ **
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ **
+ **
+ **
+ ** Pat Deegan http://flyingcarsandstuff.com
+ */
+
+#include "includes/RTCDevice.h"
+
+#ifdef USE_RTC
+#ifdef RTC32
+
+#include "wiring_rtc32.h"
+
+
+namespace RealTimeClock {
+
+uint32_t Device::offset = 0;
+
+
+DateTime Device::rebaseCounter()
+{
+	DateTime nowTime = now();
+	adjust(nowTime, true);
+	return nowTime;
+}
+void Device::adjust(const DateTime& dt, bool resetRTCCounter)
+{
+	if (resetRTCCounter)
+	{
+		wiring_rtc32_zero_clock();
+	}
+
+	offset = dt.unixtime() - (millis() / 1000);
+
+}
+void Device::setPeriodicCallback(PeriodicCallback cb, uint16_t every_seconds)
+{
+	wiring_rtc32_set_periodic_callback(cb, every_seconds);
+
+}
+
+
+void Device::clearPeriodicCallback()
+{
+
+	wiring_rtc32_set_periodic_callback(NULL, 0);
+}
+
+} /* namespace RealTimeClock */
+
+#endif /* we have RTC32 */
+#endif /* using RTC */
+
+
+
+

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTCDateTime.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTCDateTime.cpp
@@ -1,0 +1,195 @@
+/*
+ **  RTCDateTime.cpp, part of the RealTimeClock library.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ ** This code, with minor mods, is by JeeLabs (http://news.jeelabs.org/code/)
+ ** and under the public domain.  Included here because it's useful and
+ ** already familiar to many.
+ **
+ **
+*/
+#include "includes/RTCDateTime.h"
+#include "includes/RTCTimespan.h"
+
+
+#ifdef __AVR__
+ #include <avr/pgmspace.h>
+
+#else
+ #define PROGMEM
+ #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+
+#endif
+
+
+namespace RealTimeClock {
+
+#define SECONDS_PER_DAY 86400L
+
+#define SECONDS_FROM_1970_TO_2000 946684800
+
+
+////////////////////////////////////////////////////////////////////////////////
+// utility code, some of this could be exposed in the DateTime API if needed
+
+const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
+
+// number of days since 2000/01/01, valid for 2001..2099
+static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {
+    if (y >= 2000)
+        y -= 2000;
+    uint16_t days = d;
+    for (uint8_t i = 1; i < m; ++i)
+        days += pgm_read_byte(daysInMonth + i - 1);
+    if (m > 2 && y % 4 == 0)
+        ++days;
+    return days + 365 * y + (y + 3) / 4 - 1;
+}
+
+static long time2long(uint16_t days, uint8_t h, uint8_t m, uint8_t s) {
+    return ((days * 24L + h) * 60 + m) * 60 + s;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// DateTime implementation - ignores time zones and DST changes
+// NOTE: also ignores leap seconds, see http://en.wikipedia.org/wiki/Leap_second
+
+DateTime::DateTime (uint32_t t) {
+  t -= SECONDS_FROM_1970_TO_2000;    // bring to 2000 timestamp from 1970
+
+    ss = t % 60;
+    t /= 60;
+    mm = t % 60;
+    t /= 60;
+    hh = t % 24;
+    uint16_t days = t / 24;
+    uint8_t leap;
+    for (yOff = 0; ; ++yOff) {
+        leap = yOff % 4 == 0;
+        if (days < 365 + leap)
+            break;
+        days -= 365 + leap;
+    }
+    for (m = 1; ; ++m) {
+        uint8_t daysPerMonth = pgm_read_byte(daysInMonth + m - 1);
+        if (leap && m == 2)
+            ++daysPerMonth;
+        if (days < daysPerMonth)
+            break;
+        days -= daysPerMonth;
+    }
+    d = days + 1;
+}
+
+DateTime::DateTime (uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec) {
+    if (year >= 2000)
+        year -= 2000;
+    yOff = year;
+    m = month;
+    d = day;
+    hh = hour;
+    mm = min;
+    ss = sec;
+}
+
+DateTime::DateTime (const DateTime& copy):
+  yOff(copy.yOff),
+  m(copy.m),
+  d(copy.d),
+  hh(copy.hh),
+  mm(copy.mm),
+  ss(copy.ss)
+{}
+
+static uint8_t conv2d(const char* p) {
+    uint8_t v = 0;
+    if ('0' <= *p && *p <= '9')
+        v = *p - '0';
+    return 10 * v + *++p - '0';
+}
+
+// A convenient constructor for using "the compiler's time":
+//   DateTime now (__DATE__, __TIME__);
+// NOTE: using F() would further reduce the RAM footprint, see below.
+DateTime::DateTime (const char* date, const char* time) {
+    // sample input: date = "Dec 26 2009", time = "12:34:56"
+    yOff = conv2d(date + 9);
+    // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+    switch (date[0]) {
+        case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+        case 'F': m = 2; break;
+        case 'A': m = date[2] == 'r' ? 4 : 8; break;
+        case 'M': m = date[2] == 'r' ? 3 : 5; break;
+        case 'S': m = 9; break;
+        case 'O': m = 10; break;
+        case 'N': m = 11; break;
+        case 'D': m = 12; break;
+    }
+    d = conv2d(date + 4);
+    hh = conv2d(time);
+    mm = conv2d(time + 3);
+    ss = conv2d(time + 6);
+}
+
+// A convenient constructor for using "the compiler's time":
+// This version will save RAM by using PROGMEM to store it by using the F macro.
+//   DateTime now (F(__DATE__), F(__TIME__));
+DateTime::DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time) {
+    // sample input: date = "Dec 26 2009", time = "12:34:56"
+    char buff[11];
+    memcpy_P(buff, date, 11);
+    yOff = conv2d(buff + 9);
+    // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
+    switch (buff[0]) {
+        case 'J': m = buff[1] == 'a' ? 1 : m = buff[2] == 'n' ? 6 : 7; break;
+        case 'F': m = 2; break;
+        case 'A': m = buff[2] == 'r' ? 4 : 8; break;
+        case 'M': m = buff[2] == 'r' ? 3 : 5; break;
+        case 'S': m = 9; break;
+        case 'O': m = 10; break;
+        case 'N': m = 11; break;
+        case 'D': m = 12; break;
+    }
+    d = conv2d(buff + 4);
+    memcpy_P(buff, time, 8);
+    hh = conv2d(buff);
+    mm = conv2d(buff + 3);
+    ss = conv2d(buff + 6);
+}
+
+uint8_t DateTime::dayOfWeek() const {
+    uint16_t day = date2days(yOff, m, d);
+    return (day + 6) % 7; // Jan 1, 2000 is a Saturday, i.e. returns 6
+}
+
+uint32_t DateTime::unixtime(void) const {
+  uint32_t t;
+  uint16_t days = date2days(yOff, m, d);
+  t = time2long(days, hh, mm, ss);
+  t += SECONDS_FROM_1970_TO_2000;  // seconds from 1970 to 2000
+
+  return t;
+}
+
+long DateTime::secondstime(void) const {
+  long t;
+  uint16_t days = date2days(yOff, m, d);
+  t = time2long(days, hh, mm, ss);
+  return t;
+}
+
+DateTime DateTime::operator+(const TimeSpan& span) {
+  return DateTime(unixtime()+span.totalseconds());
+}
+
+DateTime DateTime::operator-(const TimeSpan& span) {
+  return DateTime(unixtime()-span.totalseconds());
+}
+
+TimeSpan DateTime::operator-(const DateTime& right) {
+  return TimeSpan(unixtime()-right.unixtime());
+}
+
+
+} /* namespace RTC */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RTCTimespan.cpp
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RTCTimespan.cpp
@@ -1,0 +1,47 @@
+/*
+ **  RTCTimespan.cpp, part of the RealTimeClock library.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ ** This code, with minor mods, is by JeeLabs (http://news.jeelabs.org/code/)
+ ** and under the public domain.  Included here because it's useful and
+ ** already familiar to many.
+ **
+ **
+*/
+
+
+#include "includes/RTCTimespan.h"
+
+namespace RealTimeClock {
+
+
+TimeSpan::TimeSpan (int32_t seconds):
+  _seconds(seconds)
+{}
+
+TimeSpan::TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds):
+  _seconds(days*86400L + hours*3600 + minutes*60 + seconds)
+{}
+
+TimeSpan::TimeSpan (const TimeSpan& copy):
+  _seconds(copy._seconds)
+{}
+
+TimeSpan TimeSpan::operator+(const TimeSpan& right) {
+  return TimeSpan(_seconds+right._seconds);
+}
+
+TimeSpan TimeSpan::operator-(const TimeSpan& right) {
+  return TimeSpan(_seconds-right._seconds);
+}
+
+
+
+} /* namespace RTC */
+
+
+
+
+
+

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RealTimeClock.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RealTimeClock.h
@@ -51,11 +51,14 @@
 #define ONBOARD_RTC_LIB_H_
 
 
-
+#include "includes/RTCIncludes.h"
 #include "includes/RTCDateTime.h"
 #include "includes/RTCTimespan.h"
 #include "includes/RTCDevice.h"
 
+#ifndef USE_RTC
+#error "You don't seem to be on a platform/variant that defines USE_RTC -- RealTimeClock library not useable"
+#endif
 
 
 

--- a/hardware/arduino/xmega/libraries/RealTimeClock/RealTimeClock.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/RealTimeClock.h
@@ -1,0 +1,62 @@
+/*
+ **  RealTimeClock library.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This library is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ ** The library incorporates public domain code, namely the DateTime and
+ ** TimeSpan implementations by JeeLabs (http://news.jeelabs.org/code/),
+ ** and retain their original licensing.
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available
+ ** on certain chips, like the Atmel XMEGA.
+ **
+ ** Along with modifications to the Xmegaduino library's wiring
+ ** implementation, this will allow you to easily deal with an
+ ** RTC-based time system.  Use this library to get and set the
+ ** real datetime, and use millis()/micros() as usual.
+ **
+ **
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ **
+ ** 	2) You are using a variant that actually enables the RTC
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ **
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ **
+ **
+ **
+ ** Pat Deegan http://flyingcarsandstuff.com
+ */
+
+#ifndef ONBOARD_RTC_LIB_H_
+#define ONBOARD_RTC_LIB_H_
+
+
+
+#include "includes/RTCDateTime.h"
+#include "includes/RTCTimespan.h"
+#include "includes/RTCDevice.h"
+
+
+
+
+#endif /* ONBOARD_RTC_LIB_H_ */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/examples/Basic/Basic.ino
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/examples/Basic/Basic.ino
@@ -1,0 +1,195 @@
+/*
+ **  RTC Basic Example
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This program (and accompanying library) is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available 
+ ** on certain chips, like the Atmel XMEGA.
+ ** 
+ ** Along with modifications to the Xmegaduino library's wiring 
+ ** implementation, this will allow you to easily deal with an 
+ ** RTC-based time system.  Use this library to get and set the 
+ ** real datetime, and use millis()/micros() as usual.
+ ** 
+ ** 
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ ** 	
+ ** 	2) You are using a variant that actually enables the RTC 
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ ** 		
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring 
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ ** 		
+ ** 
+ ** ************************* USAGE *************************
+ ** 
+ ** Update the OUTPUT_SERIAL_LINE/OUTPUT_SERIAL_BAUD as required, 
+ ** hook up a USB serial and open a terminal... inspect the code
+ ** as you watch the pretty messages scroll by.  Pretty much it.
+ ** 
+ **
+ ** The code is fully commented, see below.
+ ** Enjoy!
+ ** Pat Deegan
+ */
+
+#include <RealTimeClock.h>
+
+#define OUTPUT_SERIAL_LINE		Serial
+#define OUTPUT_SERIAL_BAUD		115200
+
+#define OUTPUT_MESSAGE(...)		OUTPUT_SERIAL_LINE.print(__VA_ARGS__);
+#define OUTPUTLN_MESSAGE(...)	OUTPUT_SERIAL_LINE.println(__VA_ARGS__);
+
+void showCurrentTime(){
+	OUTPUT_MESSAGE(F("*** "));
+	
+	RealTimeClock::DateTime nowTime = RealTimeClock::Device::now();
+	
+	if (nowTime.hour() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE((int)nowTime.hour());
+	
+	OUTPUT_MESSAGE(':');
+	
+	if (nowTime.minute() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE((int)nowTime.minute());
+
+	OUTPUT_MESSAGE(':');
+	if (nowTime.second() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUTLN_MESSAGE((int)nowTime.second());
+	
+
+}
+
+
+void myPeriodicCallback()
+{
+	// Remember that you're in the middle of an interrupt, here, so keep it snappy and simple.
+	// this is mainly useful for rebasing the counter and storing the current time to NVRAM.
+	// however, you can do whatever you need to in a timely fashion, here.
+	OUTPUT_MESSAGE(F("CALLBACK: It is now "));
+	showCurrentTime();
+
+
+	OUTPUT_MESSAGE(F("... a good time rebaseCounter()"));
+	OUTPUTLN_MESSAGE(F(" and/or backup time to NVRAM (if you have a backup battery)."));
+	OUTPUTLN_MESSAGE(' ');
+
+}
+
+void setup()
+{
+	// setup the serial line
+	OUTPUT_SERIAL_LINE.begin(OUTPUT_SERIAL_BAUD);
+
+	// begin the RTC with some valid date.
+	// datetime(year, month, day, hour, minute, seconds)
+	RealTimeClock::DateTime startDate(2014, 8, 30, 9, 35, 22); // yay, bday!
+	RealTimeClock::Device::begin(startDate);
+	
+	// you may always RealTimeClock::Device::adjust() it later.
+	
+
+	// hello message
+	OUTPUTLN_MESSAGE(F("RTC Basic example."));
+	OUTPUTLN_MESSAGE(F("Copyright (C) 2014 Pat Deegan, flyingcarsandstuff.com"));
+	OUTPUTLN_MESSAGE(' ');
+
+	OUTPUT_MESSAGE(F("Booted up, started RTC @ "));
+	OUTPUT_MESSAGE(startDate.year());
+	OUTPUT_MESSAGE('-');
+
+	if (startDate.month() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE(startDate.month());
+
+	OUTPUT_MESSAGE('-');
+
+	if (startDate.day() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUTLN_MESSAGE(startDate.day());
+
+
+	RealTimeClock::Device::setPeriodicCallback(myPeriodicCallback, 3);
+
+}
+
+void loop() {
+
+	// periodic callback should be set, we'll just wait a bit, using
+	// delayMicroseconds() to avoid triggering millis() at all
+
+	// wait for ~600*10000 us (i.e. 6 seconds)
+
+	OUTPUTLN_MESSAGE(F("A few delayMicroseconds (w/cb enabled)"));
+	for (uint16_t u=0; u<6100; u++)
+	{
+		delayMicroseconds(1000UL);
+	}
+
+	showCurrentTime();
+
+	OUTPUTLN_MESSAGE(F("A delay() (w/cb enabled)"));
+	// do it again, using delay()
+	delay(6000UL);
+	showCurrentTime();
+
+	// clear the callback, to stop getting interrupted.
+	RealTimeClock::Device::clearPeriodicCallback();
+
+	OUTPUTLN_MESSAGE(F("A couple of delayMicroseconds (no cb)"));
+	for (uint8_t i=0; i<2; i++)
+	{
+		// wait for ~2 seconds, using delayMicro
+		for (uint16_t u=0; u<2000; u++)
+		{
+			delayMicroseconds(1000UL);
+		}
+
+		showCurrentTime();
+
+	}
+
+	// a few more waits, this time with delay()
+	OUTPUTLN_MESSAGE(F("A couple of delays (no cb)"));
+	for (uint8_t i=0; i<2; i++)
+	{
+		delay(2000UL);
+		showCurrentTime();
+	}
+
+	
+	// Re-enabling the callback
+	OUTPUTLN_MESSAGE(F("Re-enabling periodic callback every 3 seconds"));
+	RealTimeClock::Device::setPeriodicCallback(myPeriodicCallback, 3);
+	
+	OUTPUTLN_MESSAGE(F("Now for one loooong delay... (20 secs)"));
+	delay(20000UL);
+	
+	OUTPUT_MESSAGE(F("Done long delay @ "));
+	showCurrentTime();
+	
+
+}

--- a/hardware/arduino/xmega/libraries/RealTimeClock/examples/BatteryBackup/BatteryBackup.ino
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/examples/BatteryBackup/BatteryBackup.ino
@@ -1,0 +1,198 @@
+/*
+ **  RTC Battery-backed RTC example.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This program (and accompanying library) is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available 
+ ** on certain chips, like the Atmel XMEGA.
+ ** 
+ ** Along with modifications to the Xmegaduino library's wiring 
+ ** implementation, this will allow you to easily deal with an 
+ ** RTC-based time system.  Use this library to get and set the 
+ ** real datetime, and use millis()/micros() as usual.
+ ** 
+ ** 
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ ** 	
+ ** 	2) You are using a variant that actually enables the RTC 
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ ** 		
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring 
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ ** 		
+ ** 
+ **
+ ** ************************* USAGE *************************
+ ** 
+ ** Update the OUTPUT_SERIAL_LINE/OUTPUT_SERIAL_BAUD as required, 
+ ** hook up a USB serial and open a terminal... inspect the code
+ ** as you watch the pretty messages scroll by.  Pretty much it.
+ ** 
+ ** 
+ ** 
+ **
+ **
+ ** The code is fully commented, see below.
+ ** Enjoy!
+ ** Pat Deegan
+ */
+
+#include <RealTimeClock.h>
+
+#define OUTPUT_SERIAL_LINE		Serial
+#define OUTPUT_SERIAL_BAUD		115200
+
+
+/*
+ * PERIODIC_CALLBACK_INTERVAL_SECONDS
+ *
+ * Interval at which we backup the current time, in seconds.
+ *
+ * Choosing this value is about finding the correct balance between
+ * resolution (PERIODIC_CALLBACK_INTERVAL_SECONDS is the max amount of
+ * time we can lose on a battery-backed RTC, like the RTC32), and how
+ * much wear-and-tear you're willing to put on your NVRAM/EEPROM/whatever.
+ *
+ */
+#define PERIODIC_CALLBACK_INTERVAL_SECONDS		5
+
+
+#define OUTPUT_MESSAGE(...)		OUTPUT_SERIAL_LINE.print(__VA_ARGS__);
+#define OUTPUTLN_MESSAGE(...)	OUTPUT_SERIAL_LINE.println(__VA_ARGS__);
+
+RealTimeClock::DateTime getLastValidTime()
+{
+	// HERE is where you would fetch the last valid time stored in EEPROM/NVRAM...
+
+	// fakin' it...
+
+	// datetime(year, month, day, hour, minute, seconds)
+	RealTimeClock::DateTime startDate(2014, 8, 30, 9, 35, 22); // yay, bday!
+	return startDate;
+}
+
+
+void myPeriodicCallback()
+{
+
+	// Remember that you're in the middle of an interrupt, here, so keep it snappy and simple.
+	RealTimeClock::DateTime nowTime = RealTimeClock::Device::rebaseCounter();
+	
+	OUTPUTLN_MESSAGE(' ');
+	
+	OUTPUT_MESSAGE(F("Storing last known start time ("));
+	OUTPUT_MESSAGE(nowTime.unixtime());
+	OUTPUTLN_MESSAGE(F(") to NVRAM (well, not really)."));
+
+
+
+	OUTPUT_MESSAGE(F("Should we lose power, the battery-backed RTC will keep counting time and, "));
+	OUTPUT_MESSAGE(F("when we reboot, we will call begin() with that value.  Thusly, the maximum time lost "));
+	OUTPUT_MESSAGE(F("will be the interval at which this function is called (here "));
+	OUTPUT_MESSAGE((int)PERIODIC_CALLBACK_INTERVAL_SECONDS);
+	OUTPUTLN_MESSAGE(F("seconds)."));
+
+	OUTPUTLN_MESSAGE(' ');
+
+}
+
+
+
+
+
+
+void setup()
+{
+	OUTPUT_SERIAL_LINE.begin(OUTPUT_SERIAL_BAUD);
+
+	RealTimeClock::DateTime lastValid = getLastValidTime();
+	RealTimeClock::Device::begin(lastValid);
+
+
+	OUTPUTLN_MESSAGE(F("RTC Battery Backup example."));
+	OUTPUTLN_MESSAGE(F("Copyright (C) 2014 Pat Deegan, flyingcarsandstuff.com"));
+	OUTPUTLN_MESSAGE(' ');
+	
+	
+	
+
+	OUTPUT_MESSAGE(F("Booted up, started RTC from last valid time: "));
+	OUTPUT_MESSAGE(lastValid.year());
+	OUTPUT_MESSAGE('-');
+
+	if (lastValid.month() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE(lastValid.month());
+
+	OUTPUT_MESSAGE('-');
+
+	if (lastValid.day() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUTLN_MESSAGE(lastValid.day());
+
+
+	RealTimeClock::Device::setPeriodicCallback(myPeriodicCallback, PERIODIC_CALLBACK_INTERVAL_SECONDS);
+
+}
+
+
+void showCurrentTime(){
+
+	RealTimeClock::DateTime nowTime = RealTimeClock::Device::now();
+
+	if (nowTime.hour() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE((int)nowTime.hour());
+
+	OUTPUT_MESSAGE(':');
+
+	if (nowTime.minute() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUT_MESSAGE((int)nowTime.minute());
+
+	OUTPUT_MESSAGE(':');
+	if (nowTime.second() < 10)
+		OUTPUT_MESSAGE('0');
+	OUTPUTLN_MESSAGE((int)nowTime.second());
+
+
+}
+
+
+void loop() {
+
+	for (uint8_t i=0; i<12; i++)
+	{
+		
+		delay(1234);
+		OUTPUT_MESSAGE(F("Just doin' my biz @ "));
+		showCurrentTime();
+	}
+	
+
+	OUTPUTLN_MESSAGE(F("Now really busy (long delay > 10s)..."));
+	for (uint16_t i=0; i<12000; i++)
+	{
+		delayMicroseconds(1000);
+	}
+
+}

--- a/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDateTime.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDateTime.h
@@ -1,0 +1,54 @@
+/*
+ **  RTCDateTime.h, part of the RealTimeClock library.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ ** This code, with minor mods, is by JeeLabs (http://news.jeelabs.org/code/)
+ ** and under the public domain.  Included here because it's useful and
+ ** already familiar to many.
+ **
+ **
+*/
+#ifndef RTCDATETIME_H_
+#define RTCDATETIME_H_
+#include "RTCIncludes.h"
+
+namespace RealTimeClock {
+
+class TimeSpan;
+
+// Simple general-purpose date/time class (no TZ / DST / leap second handling!)
+class DateTime {
+public:
+    DateTime (uint32_t t =0);
+    DateTime (uint16_t year, uint8_t month, uint8_t day,
+                uint8_t hour =0, uint8_t min =0, uint8_t sec =0);
+    DateTime (const DateTime& copy);
+    DateTime (const char* date, const char* time);
+    DateTime (const __FlashStringHelper* date, const __FlashStringHelper* time);
+    uint16_t year() const       { return 2000 + yOff; }
+    uint8_t month() const       { return m; }
+    uint8_t day() const         { return d; }
+    uint8_t hour() const        { return hh; }
+    uint8_t minute() const      { return mm; }
+    uint8_t second() const      { return ss; }
+    uint8_t dayOfWeek() const;
+
+    // 32-bit times as seconds since 1/1/2000
+    long secondstime() const;
+    // 32-bit times as seconds since 1/1/1970
+    uint32_t unixtime(void) const;
+
+    DateTime operator+(const TimeSpan& span);
+    DateTime operator-(const TimeSpan& span);
+    TimeSpan operator-(const DateTime& right);
+
+protected:
+    uint8_t yOff, m, d, hh, mm, ss;
+};
+
+} /* namespace RTC */
+
+
+
+#endif /* RTCDATETIME_H_ */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDevice.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDevice.h
@@ -61,11 +61,9 @@ typedef void(*PeriodicCallback)(void);
 class Device {
 
 public:
+	static bool wasResetAtPowerup();
     static void begin(const DateTime& dt) { adjust(dt); }
-
     static DateTime rebaseCounter();
-
-
     static void adjust(const DateTime& dt, bool resetRTCCounter=false);
     inline static DateTime now() { return (uint32_t)(offset + (millis() / 1000)); }
     static void setPeriodicCallback(PeriodicCallback cb, uint16_t every_seconds=1);

--- a/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDevice.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCDevice.h
@@ -1,0 +1,82 @@
+/*
+ **  RTCDevice.h, part of the RealTimeClock library.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This library is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ ** The library incorporates public domain code, namely the DateTime and
+ ** TimeSpan implementations by JeeLabs (http://news.jeelabs.org/code/),
+ ** and retain their original licensing.
+ **
+ ** ************************* OVERVIEW *************************
+ ** The RealTimeClock library leverages the on-board RTC available
+ ** on certain chips, like the Atmel XMEGA.
+ **
+ ** Along with modifications to the Xmegaduino library's wiring
+ ** implementation, this will allow you to easily deal with an
+ ** RTC-based time system.  Use this library to get and set the
+ ** real datetime, and use millis()/micros() as usual.
+ **
+ **
+ ** Assumptions:
+ ** 	1) You are on a platform that has either an RTC or RTC32
+ **
+ ** 	2) You are using a variant that actually enables the RTC
+ ** 		(defines USE_RTC in the pins_arduino.h)
+ **
+ ** 	3) You are using an Xmegaduino (or other Arduino compatible
+ ** 		sdk) that has implemented my mods for the RTC wiring
+ ** 		functionality (e.g. from https://github.com/psychogenic/Xmegaduino
+ ** 		or from Xmegaduino main trunk, if they've merged my pull request).
+ **
+ **
+ **
+ ** Pat Deegan http://flyingcarsandstuff.com
+ */
+
+
+#ifndef RTC_INTERFACE_H_
+#define RTC_INTERFACE_H_
+
+#include "RTCDateTime.h"
+#include "RTCTimespan.h"
+
+namespace RealTimeClock {
+
+typedef void(*PeriodicCallback)(void);
+
+class Device {
+
+public:
+    static void begin(const DateTime& dt) { adjust(dt); }
+
+    static DateTime rebaseCounter();
+
+
+    static void adjust(const DateTime& dt, bool resetRTCCounter=false);
+    inline static DateTime now() { return (uint32_t)(offset + (millis() / 1000)); }
+    static void setPeriodicCallback(PeriodicCallback cb, uint16_t every_seconds=1);
+    static void clearPeriodicCallback();
+
+protected:
+    static uint32_t offset;
+
+};
+
+
+}
+
+#endif /* RTC_H_ */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCIncludes.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCIncludes.h
@@ -1,0 +1,34 @@
+/*
+ **  RTCIncludes.h, part of the RealTimeClock library.
+ **  Copyright (C) 2014 Pat Deegan.  All rights reserved.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ **
+ ** This library is free software;
+ ** you can redistribute it and/or modify it under the terms of
+ ** the GNU Lesser General Public License as published by the
+ ** Free Software Foundation; either version 3 of the License,
+ ** or (at your option) any later version.
+ **
+ ** This program is distributed in the hope that it will be useful,
+ ** but WITHOUT ANY WARRANTY; without even the implied warranty of
+ ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ **
+ ** See file LICENSE.txt for further informations on licensing terms.
+ **
+ ** The library incorporates public domain code, namely the DateTime and
+ ** TimeSpan implementations by JeeLabs (http://news.jeelabs.org/code/),
+ ** and retain their original licensing.
+ **
+*/
+
+#ifndef RTCINCLUDES_H_
+#define RTCINCLUDES_H_
+
+#include <stdint.h>
+#include <inttypes.h>
+#include "Arduino.h"
+
+
+#endif /* RTCINCLUDES_H_ */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCTimespan.h
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/includes/RTCTimespan.h
@@ -1,0 +1,46 @@
+/*
+ **  RTCTimespan.h, part of the RealTimeClock library.
+ **
+ ** http://www.flyingcarsandstuff.com/projects/RealTimeClock
+ **
+ ** This code, with minor mods, is by JeeLabs (http://news.jeelabs.org/code/)
+ ** and under the public domain.  Included here because it's useful and
+ ** already familiar to many.
+ **
+ **
+*/
+
+#ifndef RTCTIMESPAN_H_
+#define RTCTIMESPAN_H_
+
+
+#include "RTCIncludes.h"
+
+
+namespace RealTimeClock {
+
+// Timespan which can represent changes in time with seconds accuracy.
+class TimeSpan {
+public:
+    TimeSpan (int32_t seconds = 0);
+    TimeSpan (int16_t days, int8_t hours, int8_t minutes, int8_t seconds);
+    TimeSpan (const TimeSpan& copy);
+    int16_t days() const         { return _seconds / 86400L; }
+    int8_t  hours() const        { return _seconds / 3600 % 24; }
+    int8_t  minutes() const      { return _seconds / 60 % 60; }
+    int8_t  seconds() const      { return _seconds % 60; }
+    int32_t totalseconds() const { return _seconds; }
+
+    TimeSpan operator+(const TimeSpan& right);
+    TimeSpan operator-(const TimeSpan& right);
+
+protected:
+    int32_t _seconds;
+};
+
+
+} /* namespace RTC */
+
+
+
+#endif /* RTCTIMESPAN_H_ */

--- a/hardware/arduino/xmega/libraries/RealTimeClock/keywords.txt
+++ b/hardware/arduino/xmega/libraries/RealTimeClock/keywords.txt
@@ -1,0 +1,32 @@
+#######################################
+# Syntax Coloring Map For TinyBrite
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+RealTimeClock	KEYWORD1
+DateTime		KEYWORD1
+TimeSpan	KEYWORD1
+
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+begin	KEYWORD2
+rebaseCounter	KEYWORD2
+adjust	KEYWORD2
+now	KEYWORD2
+setPeriodicCallback	KEYWORD2
+clearPeriodicCallback	KEYWORD2
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+

--- a/hardware/arduino/xmega/libraries/Wire/Wire.cpp
+++ b/hardware/arduino/xmega/libraries/Wire/Wire.cpp
@@ -84,7 +84,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop
     quantity = BUFFER_LENGTH;
   }
   // perform blocking read into buffer
-  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
+  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop, auto_timeout);
   // set rx buffer iterator vars
   rxBufferIndex = 0;
   rxBufferLength = read;

--- a/hardware/arduino/xmega/libraries/Wire/Wire.h
+++ b/hardware/arduino/xmega/libraries/Wire/Wire.h
@@ -168,7 +168,7 @@ extern TwoWire Wire;
 /**
  * Timeout, if using autoTimeout()
  */
-#define TWI_ERROR_TIMOUT 12
+#define TWI_ERROR_TIMEOUT 12
 
 /** 
  * Error code reported by a xmWire class method :

--- a/hardware/arduino/xmega/libraries/Wire/Wire.h
+++ b/hardware/arduino/xmega/libraries/Wire/Wire.h
@@ -25,6 +25,8 @@
 #include <inttypes.h>
 #include "Stream.h"
 
+typedef uint8_t AutoTimeoutMs;
+
 #if !defined(__AVR_XMEGA__)
 
 #define BUFFER_LENGTH 32
@@ -46,6 +48,8 @@ class TwoWire : public Stream
     static void (*user_onReceive)(int);
     static void onRequestService(void);
     static void onReceiveService(uint8_t*, int);
+
+    AutoTimeoutMs auto_timeout;
   public:
     TwoWire();
     void begin();
@@ -72,6 +76,11 @@ class TwoWire : public Stream
     inline size_t write(long n) { return write((uint8_t)n); }
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
+
+
+    inline AutoTimeoutMs autoTimeout() { return auto_timeout;}
+    inline void setAutoTimeout(AutoTimeoutMs ms) { auto_timeout = ms;}
+
     using Print::write;
 };
 
@@ -154,6 +163,13 @@ extern TwoWire Wire;
  * is in progress.
  */
 #define TWI_NOT_TRANSMITTING 11
+
+
+/**
+ * Timeout, if using autoTimeout()
+ */
+#define TWI_ERROR_TIMOUT 12
+
 /** 
  * Error code reported by a xmWire class method :
  * This has to be implemented in  a future release.
@@ -243,6 +259,7 @@ class xmWire : public Stream {
     /** True if the bus is currently busy */
     //    volatile boolean busy;
      
+    AutoTimeoutMs auto_timeout;
   public:
     /** 
      * Create a new instance of a TWI port
@@ -361,6 +378,10 @@ class xmWire : public Stream {
      * Our internal interrupt handler
      */
     void onMasterInterrupt();
+
+    inline AutoTimeoutMs autoTimeout() { return auto_timeout;}
+    inline void setAutoTimeout(AutoTimeoutMs ms) { auto_timeout = ms;}
+
 
     using Print::write;
 };

--- a/hardware/arduino/xmega/libraries/Wire/utility/twi.c
+++ b/hardware/arduino/xmega/libraries/Wire/utility/twi.c
@@ -114,17 +114,25 @@ void twi_setAddress(uint8_t address)
  *          sendStop: Boolean indicating whether to send a stop at the end
  * Output   number of bytes read
  */
-uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop)
+uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sendStop, uint8_t timeoutMs)
 {
   uint8_t i;
-
+  uint32_t timeoutTime = 0;
   // ensure data will fit into buffer
   if(TWI_BUFFER_LENGTH < length){
     return 0;
   }
 
+  if (timeoutMs)
+  {
+     timeoutTime = millis() + timeoutMs;
+  }
   // wait until twi is ready, become master receiver
   while(TWI_READY != twi_state){
+ 
+    if (timeoutTime && millis() > timeoutTime)
+	return 0;
+
     continue;
   }
   twi_state = TWI_MRX;
@@ -162,6 +170,9 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
 
   // wait for read operation to complete
   while(TWI_MRX == twi_state){
+    if (timeoutTime && millis() > timeoutTime)
+	return 0;
+
     continue;
   }
 

--- a/hardware/arduino/xmega/libraries/Wire/utility/twi.h
+++ b/hardware/arduino/xmega/libraries/Wire/utility/twi.h
@@ -42,7 +42,7 @@
   
   void twi_init(void);
   void twi_setAddress(uint8_t);
-  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
+  uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t timeoutMs=0);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
   void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );

--- a/hardware/arduino/xmega/libraries/Wire/xmWire.cpp
+++ b/hardware/arduino/xmega/libraries/Wire/xmWire.cpp
@@ -126,7 +126,7 @@ int xmWire::beginTransmission(uint8_t slaveAddress) {
     while(!ready())  // Wait for Wire to become available
     {
         if (timeoutTimeMs && millis() > timeoutTimeMs)
-            return TWI_ERROR_TIMOUT;
+            return TWI_ERROR_TIMEOUT;
 
         continue;
     }
@@ -202,7 +202,7 @@ int xmWire::requestFrom(uint8_t slaveAddress, int expectedByteCount) {
 
     while(!ready()) {
         if (timeoutTimeMs && millis() > timeoutTimeMs)
-            return TWI_ERROR_TIMOUT;
+            return TWI_ERROR_TIMEOUT;
     }
     if(slaveAddress==0 || slaveAddress>127)
 	return TWI_ERROR_ADDRESS;


### PR DESCRIPTION
The Wire library freezes programs whenever there's a problem on the line (e.g. unresponsive slave)... This patch leaves things exactly as-is, by default, but allows you to:

  Wire.setAutoTimeout(UINT8); // set auto timeouts to a value between 0 (disabled) and 255 ms

Then proceed as usual. If auto-timeout is set, Xmega (xmWire) version may return TWI_ERROR_TIMEOUT errors on beginTransmission() and requestFrom(), should a timeout occur.  As it doesn't have a facility for elaborate error reporting, the Mega version simply returns 0 length read on timeouts from readFrom().
